### PR TITLE
fix broken link to mastering emacs intro to magit

### DIFF
--- a/documentation.html
+++ b/documentation.html
@@ -52,7 +52,7 @@
 
         <h2>External Documentation</h2>
           <li>
-            <a href="http://www.masteringemacs.org/articles/2013/12/06/introduction-magit-emacs-mode-git">
+            <a href="http://www.masteringemacs.org/article/introduction-magit-emacs-mode-git">
               Introduction on Mastering Emacs
             </a>
           </li>


### PR DESCRIPTION
Looks like the recent [Mastering Emacs](http://www.masteringemacs.org) site [overhaul](http://www.masteringemacs.org/article/four-year-anniversary-new-website) changed the article slugs. This updates the link for the intro to magit article.
